### PR TITLE
feat(statistics): add monthly budget APIs (GET/POST/PATCH) with valid…

### DIFF
--- a/backend/controllers/statistic.controller.js
+++ b/backend/controllers/statistic.controller.js
@@ -21,3 +21,41 @@ exports.getSummary = async (req, res, next) => {
     next(error);
   }
 };
+
+exports.getBudget = async (req, res, next) => {
+  try {
+    const userId = req.user._id;
+    const month = Number(req.query.month);
+    const year = Number(req.query.year);
+
+    const data = await statisticService.getBudgetSummary(userId, month, year);
+
+    return res
+      .status(200)
+      .json(successResponse(200, "Get monthly budget successfully", data));
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.saveBudget = async (req, res, next) => {
+  try {
+    const userId = req.user._id;
+    const month = Number(req.body.month);
+    const year = Number(req.body.year);
+    const targetAmount = Number(req.body.targetAmount);
+
+    const data = await statisticService.saveBudgetTarget(
+      userId,
+      month,
+      year,
+      targetAmount
+    );
+
+    return res
+      .status(200)
+      .json(successResponse(200, "Save monthly budget successfully", data));
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/models/monthly_budget.model.js
+++ b/backend/models/monthly_budget.model.js
@@ -1,0 +1,35 @@
+const mongoose = require("mongoose");
+
+const monthlyBudgetSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    month: {
+      type: Number,
+      required: true,
+      min: 1,
+      max: 12,
+    },
+    year: {
+      type: Number,
+      required: true,
+      min: 2000,
+    },
+    targetAmount: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+monthlyBudgetSchema.index({ userId: 1, month: 1, year: 1 }, { unique: true });
+
+module.exports = mongoose.model("MonthlyBudget", monthlyBudgetSchema);

--- a/backend/routes/statistic_routes.js
+++ b/backend/routes/statistic_routes.js
@@ -7,7 +7,11 @@ const router = express.Router();
 const statisticController = require("../controllers/statistic.controller");
 const authenticate = require("../middleware/auth.middleware");
 const validate = require("../middleware/validate.middleware");
-const { getSummarySchema } = require("../validators/statistic.validator");
+const {
+	getSummarySchema,
+	getBudgetSchema,
+	saveBudgetSchema,
+} = require("../validators/statistic.validator");
 
 /**
  * @swagger
@@ -57,5 +61,23 @@ const { getSummarySchema } = require("../validators/statistic.validator");
  *         description: Unauthorized
  */
 router.get("/summary", authenticate,validate(getSummarySchema, "query"), statisticController.getSummary);
+router.get(
+	"/budget",
+	authenticate,
+	validate(getBudgetSchema, "query"),
+	statisticController.getBudget
+);
+router.post(
+	"/budget",
+	authenticate,
+	validate(saveBudgetSchema, "body"),
+	statisticController.saveBudget
+);
+router.patch(
+	"/budget",
+	authenticate,
+	validate(saveBudgetSchema, "body"),
+	statisticController.saveBudget
+);
 
 module.exports = router;

--- a/backend/services/statistic.service.js
+++ b/backend/services/statistic.service.js
@@ -3,6 +3,7 @@
  */
 
 const Transaction = require("../models/transaction_schema");
+const MonthlyBudget = require("../models/monthly_budget.model");
 const mongoose = require("mongoose");
 
 /**
@@ -83,8 +84,50 @@ const getMonthlyStatistics = async (userId, month, year) => {
   return getStatistics(userId, { month, year });
 };
 
+const computeBudgetStatus = (targetAmount, actualExpense) => {
+  if (targetAmount <= 0) return "safe";
+  if (actualExpense > targetAmount) return "over";
+
+  const ratio = actualExpense / targetAmount;
+  if (ratio >= 0.8) return "near";
+
+  return "safe";
+};
+
+const getBudgetSummary = async (userId, month, year) => {
+  const budget = await MonthlyBudget.findOne({ userId, month, year }).lean();
+  const targetAmount = budget?.targetAmount ?? 0;
+
+  const stats = await getStatistics(userId, { month, year });
+  const actualExpense = stats.totalExpense;
+  const remaining = targetAmount - actualExpense;
+  const status = computeBudgetStatus(targetAmount, actualExpense);
+
+  return {
+    month,
+    year,
+    targetAmount,
+    actualExpense,
+    remaining,
+    status,
+  };
+};
+
+const saveBudgetTarget = async (userId, month, year, targetAmount) => {
+  await MonthlyBudget.findOneAndUpdate(
+    { userId, month, year },
+    { $set: { targetAmount } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  return getBudgetSummary(userId, month, year);
+};
+
 module.exports = {
   getStatistics,
   getCategoryBreakdown,
   getMonthlyStatistics,
+  getBudgetSummary,
+  saveBudgetTarget,
+  computeBudgetStatus,
 };

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -11,6 +11,8 @@ servers:
 tags:
   - name: Transactions
     description: Transaction endpoints
+  - name: Statistics
+    description: Statistics and monthly budget endpoints
 
 paths:
   /api/transactions:
@@ -330,6 +332,150 @@ paths:
                 statusCode: 404
                 message: Transaction not found or permission denied
 
+  /api/statistics/summary:
+    get:
+      tags:
+        - Statistics
+      summary: Get monthly income and expense summary
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: month
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+        - in: query
+          name: year
+          required: true
+          schema:
+            type: integer
+            minimum: 2000
+      responses:
+        '200':
+          description: Statistics fetched successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  statusCode:
+                    type: integer
+                  message:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      totalIncome:
+                        type: number
+                      totalExpense:
+                        type: number
+                      balance:
+                        type: number
+        '400':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Unauthorized
+
+  /api/statistics/budget:
+    get:
+      tags:
+        - Statistics
+      summary: Get monthly budget summary
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: month
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+        - in: query
+          name: year
+          required: true
+          schema:
+            type: integer
+            minimum: 2000
+      responses:
+        '200':
+          description: Budget summary fetched successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetSummarySuccess'
+        '400':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Unauthorized
+    post:
+      tags:
+        - Statistics
+      summary: Save or update monthly budget target
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetSaveInput'
+      responses:
+        '200':
+          description: Budget target saved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetSummarySuccess'
+        '400':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Unauthorized
+    patch:
+      tags:
+        - Statistics
+      summary: Patch monthly budget target
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BudgetSaveInput'
+      responses:
+        '200':
+          description: Budget target updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BudgetSummarySuccess'
+        '400':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Unauthorized
+
 components:
   securitySchemes:
     bearerAuth:
@@ -366,6 +512,47 @@ components:
         updatedAt:
           type: string
           format: date-time
+    BudgetSaveInput:
+      type: object
+      required: [month, year, targetAmount]
+      properties:
+        month:
+          type: integer
+          minimum: 1
+          maximum: 12
+        year:
+          type: integer
+          minimum: 2000
+        targetAmount:
+          type: number
+          exclusiveMinimum: 0
+    BudgetSummary:
+      type: object
+      properties:
+        month:
+          type: integer
+        year:
+          type: integer
+        targetAmount:
+          type: number
+        actualExpense:
+          type: number
+        remaining:
+          type: number
+        status:
+          type: string
+          enum: [safe, near, over]
+    BudgetSummarySuccess:
+      type: object
+      properties:
+        success:
+          type: boolean
+        statusCode:
+          type: integer
+        message:
+          type: string
+        data:
+          $ref: '#/components/schemas/BudgetSummary'
 
     TransactionCreateInput:
       type: object

--- a/backend/tests/integration/statistic.routes.test.js
+++ b/backend/tests/integration/statistic.routes.test.js
@@ -13,6 +13,8 @@ const { TextEncoder } = require("util");
 // Mock service để tránh truy cập DB thật
 jest.mock("../../services/statistic.service", () => ({
   getMonthlyStatistics: jest.fn(),
+  getBudgetSummary: jest.fn(),
+  saveBudgetTarget: jest.fn(),
 }));
 
 const statisticService = require("../../services/statistic.service");
@@ -80,4 +82,121 @@ describe("GET /api/statistics/summary", () => {
       "2026",
     );
   }, 10000);
+});
+
+describe("Budget endpoints /api/statistics/budget", () => {
+  let token;
+  const mockUserId = new mongoose.Types.ObjectId().toString();
+  const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+
+  beforeAll(async () => {
+    token = await new SignJWT({ userId: mockUserId })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(secret);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 200 for GET budget when valid", async () => {
+    const mockData = {
+      month: 4,
+      year: 2026,
+      targetAmount: 1000000,
+      actualExpense: 700000,
+      remaining: 300000,
+      status: "safe",
+    };
+
+    statisticService.getBudgetSummary.mockResolvedValue(mockData);
+
+    const res = await request(app)
+      .get("/api/statistics/budget")
+      .set("Authorization", `Bearer ${token}`)
+      .query({ month: 4, year: 2026 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(mockData);
+    expect(statisticService.getBudgetSummary).toHaveBeenCalledWith(
+      mockUserId,
+      4,
+      2026
+    );
+  });
+
+  it("should return 400 for GET budget with invalid month", async () => {
+    const res = await request(app)
+      .get("/api/statistics/budget")
+      .set("Authorization", `Bearer ${token}`)
+      .query({ month: 13, year: 2026 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("Validation failed");
+  });
+
+  it("should return 200 for POST budget when valid", async () => {
+    const mockData = {
+      month: 4,
+      year: 2026,
+      targetAmount: 1000000,
+      actualExpense: 700000,
+      remaining: 300000,
+      status: "safe",
+    };
+
+    statisticService.saveBudgetTarget.mockResolvedValue(mockData);
+
+    const res = await request(app)
+      .post("/api/statistics/budget")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ month: 4, year: 2026, targetAmount: 1000000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(mockData);
+    expect(statisticService.saveBudgetTarget).toHaveBeenCalledWith(
+      mockUserId,
+      4,
+      2026,
+      1000000
+    );
+  });
+
+  it("should return 400 for POST budget with targetAmount <= 0", async () => {
+    const res = await request(app)
+      .post("/api/statistics/budget")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ month: 4, year: 2026, targetAmount: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("Validation failed");
+  });
+
+  it("should return 200 for PATCH budget when valid", async () => {
+    const mockData = {
+      month: 4,
+      year: 2026,
+      targetAmount: 1200000,
+      actualExpense: 700000,
+      remaining: 500000,
+      status: "safe",
+    };
+
+    statisticService.saveBudgetTarget.mockResolvedValue(mockData);
+
+    const res = await request(app)
+      .patch("/api/statistics/budget")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ month: 4, year: 2026, targetAmount: 1200000 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(mockData);
+  });
 });

--- a/backend/tests/unit/services/statistic.service.test.js
+++ b/backend/tests/unit/services/statistic.service.test.js
@@ -11,11 +11,20 @@ jest.mock("../../../models/transaction_schema", () => ({
   aggregate: jest.fn(),
 }));
 
+jest.mock("../../../models/monthly_budget.model", () => ({
+  findOne: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
 const Transaction = require('../../../models/transaction_schema');
+const MonthlyBudget = require("../../../models/monthly_budget.model");
 const {
   getStatistics,
   getCategoryBreakdown,
   getMonthlyStatistics,
+  getBudgetSummary,
+  saveBudgetTarget,
+  computeBudgetStatus,
 } = require('../../../services/statistic.service');
 const mongoose = require('mongoose');
 
@@ -27,6 +36,10 @@ describe('Statistic Service - getMonthlyStatistics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Transaction.aggregate.mockResolvedValue([]);
+    MonthlyBudget.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue(null),
+    });
+    MonthlyBudget.findOneAndUpdate.mockResolvedValue(null);
   });
 
   // Test cho hàm getStatistics, chúng ta sẽ kiểm tra xem hàm có trả về tổng thu, chi và số dư đúng không khi có dữ liệu giả, cũng như khi không có dữ liệu nào.
@@ -82,6 +95,79 @@ describe('Statistic Service - getMonthlyStatistics', () => {
       Transaction.aggregate.mockResolvedValue([]);
       await getMonthlyStatistics(userId, 2, 2026);
       expect(Transaction.aggregate).toHaveBeenCalled();
+    });
+  });
+
+  describe("computeBudgetStatus", () => {
+    it("returns safe when no target budget", () => {
+      expect(computeBudgetStatus(0, 100)).toBe("safe");
+    });
+
+    it("returns over when actual is greater than target", () => {
+      expect(computeBudgetStatus(100, 101)).toBe("over");
+    });
+
+    it("returns near at 80 percent threshold", () => {
+      expect(computeBudgetStatus(100, 80)).toBe("near");
+    });
+  });
+
+  describe("getBudgetSummary", () => {
+    it("returns budget summary with default targetAmount = 0", async () => {
+      Transaction.aggregate.mockResolvedValue([{ totalIncome: 0, totalExpense: 300 }]);
+
+      const result = await getBudgetSummary(userId, 4, 2026);
+
+      expect(result).toEqual({
+        month: 4,
+        year: 2026,
+        targetAmount: 0,
+        actualExpense: 300,
+        remaining: -300,
+        status: "safe",
+      });
+      expect(MonthlyBudget.findOne).toHaveBeenCalledWith({
+        userId,
+        month: 4,
+        year: 2026,
+      });
+    });
+
+    it("returns near when ratio is between 0.8 and 1.0", async () => {
+      MonthlyBudget.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ targetAmount: 1000 }),
+      });
+      Transaction.aggregate.mockResolvedValue([{ totalIncome: 0, totalExpense: 800 }]);
+
+      const result = await getBudgetSummary(userId, 4, 2026);
+
+      expect(result.status).toBe("near");
+      expect(result.remaining).toBe(200);
+    });
+  });
+
+  describe("saveBudgetTarget", () => {
+    it("upserts monthly budget and returns summary", async () => {
+      MonthlyBudget.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ targetAmount: 900 }),
+      });
+      Transaction.aggregate.mockResolvedValue([{ totalIncome: 0, totalExpense: 200 }]);
+
+      const result = await saveBudgetTarget(userId, 5, 2026, 900);
+
+      expect(MonthlyBudget.findOneAndUpdate).toHaveBeenCalledWith(
+        { userId, month: 5, year: 2026 },
+        { $set: { targetAmount: 900 } },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      );
+      expect(result).toEqual({
+        month: 5,
+        year: 2026,
+        targetAmount: 900,
+        actualExpense: 200,
+        remaining: 700,
+        status: "safe",
+      });
     });
   });
 });

--- a/backend/tests/unit/validators/statistic.validator.test.js
+++ b/backend/tests/unit/validators/statistic.validator.test.js
@@ -6,7 +6,11 @@
  *   - Sử dụng Joi để validate và kiểm tra kết quả trả về
  */
 
-const { getSummarySchema } = require("../../../validators/statistic.validator");
+const {
+  getSummarySchema,
+  getBudgetSchema,
+  saveBudgetSchema,
+} = require("../../../validators/statistic.validator");
 
 // Test cases cho validator thống kê thu chi
 describe("Statistic Validator", () => {
@@ -17,5 +21,43 @@ describe("Statistic Validator", () => {
     });
 
     expect(result.error).toBeUndefined();
+  });
+
+  it("valid get budget input", () => {
+    const result = getBudgetSchema.validate({
+      month: 4,
+      year: 2026,
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it("invalid get budget month", () => {
+    const result = getBudgetSchema.validate({
+      month: 13,
+      year: 2026,
+    });
+
+    expect(result.error).toBeDefined();
+  });
+
+  it("valid save budget input", () => {
+    const result = saveBudgetSchema.validate({
+      month: 4,
+      year: 2026,
+      targetAmount: 500000,
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it("invalid save budget targetAmount <= 0", () => {
+    const result = saveBudgetSchema.validate({
+      month: 4,
+      year: 2026,
+      targetAmount: 0,
+    });
+
+    expect(result.error).toBeDefined();
   });
 });

--- a/backend/validators/statistic.validator.js
+++ b/backend/validators/statistic.validator.js
@@ -11,4 +11,15 @@ const getSummarySchema = Joi.object({
   year: Joi.number().integer().min(2000).required(),
 });
 
-module.exports = { getSummarySchema };
+const getBudgetSchema = Joi.object({
+  month: Joi.number().integer().min(1).max(12).required(),
+  year: Joi.number().integer().min(2000).required(),
+});
+
+const saveBudgetSchema = Joi.object({
+  month: Joi.number().integer().min(1).max(12).required(),
+  year: Joi.number().integer().min(2000).required(),
+  targetAmount: Joi.number().positive().required(),
+});
+
+module.exports = { getSummarySchema, getBudgetSchema, saveBudgetSchema };


### PR DESCRIPTION
🚀 Nội dung thay đổi (What's new?)
Xây dựng API Budget tháng cho Statistics để Mobile có thể đọc/lưu mục tiêu chi tiêu theo tháng.

Thêm endpoint mới:

GET /api/statistics/budget?month=&year=: trả về budget summary theo contract
POST /api/statistics/budget: lưu mới target budget theo tháng
PATCH /api/statistics/budget: cập nhật target budget theo tháng
Triển khai logic service:

Tính actualExpense từ transactions theo tháng
Tính remaining = targetAmount - actualExpense
Tính status theo rule:
safe: ratio < 0.8 hoặc chưa có target (targetAmount = 0)
near: 0.8 <= ratio <= 1.0
over: actualExpense > targetAmount
Thêm model budget tháng riêng với unique key (userId, month, year) để tránh trùng dữ liệu và hỗ trợ upsert.

Thêm validation:
month trong khoảng 1-12
year >= 2000
targetAmount > 0 với POST/PATCH
Cập nhật Swagger/OpenAPI cho budget endpoints và schema response.

Bổ sung test:

Integration test cho route budget (GET/POST/PATCH + case invalid)
Unit test cho validator budget
Unit test cho service budget (status/summary/save)
Đảm bảo không ảnh hưởng endpoint statistics summary hiện có.


